### PR TITLE
Add all DD masters to the link cache

### DIFF
--- a/UDPatcher/Program.cs
+++ b/UDPatcher/Program.cs
@@ -524,12 +524,6 @@ namespace UDPatcher
                 "UnforgivingDevices.esp"
             };
 
-/*            const string DDI_NAME = "Devious Devices - Integration.esm";
-            ModKey ddiMod = ModKey.FromFileName(DDI_NAME);
-
-            const string UD_NAME = "UnforgivingDevices.esp";
-            ModKey udMod = ModKey.FromFileName(UD_NAME);*/
-
             var modsToPatch = Settings.ModsToPatch;
 
             var modsToNotPatch = Settings.ModsToNotPatch;
@@ -544,9 +538,6 @@ namespace UDPatcher
                 modsToPatch.Contains(mod.ModKey) && !modsToNotPatch.Contains(mod.ModKey)
                 ) : state.LoadOrder.PriorityOrder.Where(mod => !modsToNotPatch.Contains(mod.ModKey));
             Console.WriteLine($"Found mods:\n{string.Join("\n", shortenedLoadOrder.Reverse())}");
-/*            var shortenedLoadOrderFuller = modsToPatch.Any() ? state.LoadOrder.ListedOrder.Where(mod =>
-                modsToPatch.Contains(mod.ModKey) || mod.ModKey == ddiMod || mod.ModKey == udMod || 
-                ) : state.LoadOrder.ListedOrder;*/
             var shortenedLoadOrderFuller = modsToPatch.Any() ? state.LoadOrder.ListedOrder.Where(mod =>
                 modsToPatch.Contains(mod.ModKey) || MASTER_MODS.Contains(mod.ModKey.ToString())
                 ) : state.LoadOrder.ListedOrder;

--- a/UDPatcher/Program.cs
+++ b/UDPatcher/Program.cs
@@ -515,11 +515,20 @@ namespace UDPatcher
             var UDScripts = GetAllUdScriptNamesFromSettings();
             var zadScripts = GetAllZadScriptNamesFromSettings();
 
-            const string DDI_NAME = "Devious Devices - Integration.esm";
+            HashSet<string> MASTER_MODS = new HashSet<string>()
+            {
+                "Devious Devices - Integration.esm",
+                "Devious Devices - Assets.esm",
+                "Devious Devices - Expansion.esm",
+                "Devious Devices - Contraptions.esm",
+                "UnforgivingDevices.esp"
+            };
+
+/*            const string DDI_NAME = "Devious Devices - Integration.esm";
             ModKey ddiMod = ModKey.FromFileName(DDI_NAME);
 
             const string UD_NAME = "UnforgivingDevices.esp";
-            ModKey udMod = ModKey.FromFileName(UD_NAME);
+            ModKey udMod = ModKey.FromFileName(UD_NAME);*/
 
             var modsToPatch = Settings.ModsToPatch;
 
@@ -535,10 +544,12 @@ namespace UDPatcher
                 modsToPatch.Contains(mod.ModKey) && !modsToNotPatch.Contains(mod.ModKey)
                 ) : state.LoadOrder.PriorityOrder.Where(mod => !modsToNotPatch.Contains(mod.ModKey));
             Console.WriteLine($"Found mods:\n{string.Join("\n", shortenedLoadOrder.Reverse())}");
+/*            var shortenedLoadOrderFuller = modsToPatch.Any() ? state.LoadOrder.ListedOrder.Where(mod =>
+                modsToPatch.Contains(mod.ModKey) || mod.ModKey == ddiMod || mod.ModKey == udMod || 
+                ) : state.LoadOrder.ListedOrder;*/
             var shortenedLoadOrderFuller = modsToPatch.Any() ? state.LoadOrder.ListedOrder.Where(mod =>
-                modsToPatch.Contains(mod.ModKey) || mod.ModKey == ddiMod || mod.ModKey == udMod
+                modsToPatch.Contains(mod.ModKey) || MASTER_MODS.Contains(mod.ModKey.ToString())
                 ) : state.LoadOrder.ListedOrder;
-
 
             var idLinkCache = shortenedLoadOrderFuller.ToImmutableLinkCache<ISkyrimMod, ISkyrimModGetter>(LinkCachePreferences.Default);
 


### PR DESCRIPTION
This will prevent unwanted errors for mods which reference the DD devices, as the patcher will now be able to see those references. tested and appears to work.